### PR TITLE
Initialize method created to prevent problems with converters initial…

### DIFF
--- a/src/msgpack.light/MsgPackContext.cs
+++ b/src/msgpack.light/MsgPackContext.cs
@@ -9,8 +9,6 @@ namespace MsgPack.Light
 {
     public class MsgPackContext
     {
-        private bool _isInitialized = false;
-
         private static readonly IMsgPackConverter<object> SharedNullConverter = new NullConverter();
 
         private readonly Dictionary<Type, IMsgPackConverter> _converters = new Dictionary<Type, IMsgPackConverter>
@@ -56,8 +54,6 @@ namespace MsgPack.Light
             {
                 converter.Value.Initialize(this);
             }
-
-            _isInitialized = true;
         }
 
         public IMsgPackConverter<object> NullConverter => SharedNullConverter;
@@ -81,11 +77,6 @@ namespace MsgPack.Light
 
         public IMsgPackConverter<T> GetConverter<T>()
         {
-            if (!_isInitialized)
-            {
-                throw new InvalidOperationException("MsgPackContext is not initialized yet!");
-            }
-
             var type = typeof(T);
             var result = (IMsgPackConverter<T>)GetConverterFromCache<T>();
             if (result != null)

--- a/src/msgpack.light/MsgPackSerializer.cs
+++ b/src/msgpack.light/MsgPackSerializer.cs
@@ -9,7 +9,10 @@ namespace MsgPack.Light
     {
         public static byte[] Serialize<T>(T data)
         {
-            return Serialize(data, new MsgPackContext());
+            var context = new MsgPackContext();
+            context.Initialize();
+
+            return Serialize(data, context);
         }
 
         public static byte[] Serialize<T>(T data, [NotNull]MsgPackContext context)
@@ -25,7 +28,10 @@ namespace MsgPack.Light
 
         public static void Serialize<T>(T data, MemoryStream stream)
         {
-            Serialize(data, stream, new MsgPackContext());
+            var context = new MsgPackContext();
+            context.Initialize();
+
+            Serialize(data, stream, context);
         }
 
         public static void Serialize<T>(T data, MemoryStream stream, [NotNull]MsgPackContext context)
@@ -39,7 +45,10 @@ namespace MsgPack.Light
 
         public static T Deserialize<T>(byte[] data)
         {
-            return Deserialize<T>(data, new MsgPackContext());
+            var context  = new MsgPackContext();
+            context.Initialize();
+
+            return Deserialize<T>(data, context);
         }
 
         public static T Deserialize<T>(byte[] data, [NotNull]MsgPackContext context)
@@ -51,7 +60,10 @@ namespace MsgPack.Light
 
         public static T Deserialize<T>(MemoryStream stream)
         {
-            return Deserialize<T>(stream, new MsgPackContext());
+            var context = new MsgPackContext();
+            context.Initialize();
+
+            return Deserialize<T>(stream, context);
         }
 
         public static T Deserialize<T>(MemoryStream stream, [NotNull]MsgPackContext context)

--- a/tests/msgpack.light.tests/Reader/Array.cs
+++ b/tests/msgpack.light.tests/Reader/Array.cs
@@ -64,6 +64,7 @@ namespace MsgPack.Light.Tests.Reader
 
             var settings = new MsgPackContext();
             settings.RegisterConverter(new TestReflectionConverter());
+            settings.Initialize();
 
             MsgPackSerializer.Deserialize<object[]>(data, settings).ShouldBe(expected);
         }

--- a/tests/msgpack.light.tests/Reader/Map.cs
+++ b/tests/msgpack.light.tests/Reader/Map.cs
@@ -53,6 +53,8 @@ namespace MsgPack.Light.Tests.Reader
 
             var settings = new MsgPackContext();
             settings.RegisterConverter(new TestReflectionConverter());
+            settings.Initialize();
+
             MsgPackSerializer.Serialize(tests, settings).ShouldBe(data);
         }
 

--- a/tests/msgpack.light.tests/Writer/Array.cs
+++ b/tests/msgpack.light.tests/Writer/Array.cs
@@ -65,6 +65,8 @@ namespace MsgPack.Light.Tests.Writer
 
             var settings = new MsgPackContext();
             settings.RegisterConverter(new TestReflectionConverter());
+            settings.Initialize();
+
             MsgPackSerializer.Serialize(tests, settings).ShouldBe(data);
         }
     }

--- a/tests/msgpack.light.tests/Writer/Map.cs
+++ b/tests/msgpack.light.tests/Writer/Map.cs
@@ -53,6 +53,8 @@ namespace MsgPack.Light.Tests.Writer
 
             var settings = new MsgPackContext();
             settings.RegisterConverter(new TestReflectionConverter());
+            settings.Initialize();
+
             MsgPackSerializer.Serialize(tests, settings).ShouldBe(data);
         }
 


### PR DESCRIPTION
The problem is the following:
If user have a lot of converters, which uses each other, converters should be initialized in proper order (if AConveter use BConverter, BConverter should be initialized before AConverter). 
Solution is to initialize all converters after they are registred.
