### PR TITLE
CI fix for the case when PR is from forked repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build, Test & Publish nuget
+name: Build, Test & Pack nuget
 
 on:
   push:
@@ -30,18 +30,21 @@ jobs:
       run: dotnet build -c Release --no-restore
     - name: Tests
       run: dotnet test -c Release --no-build --verbosity normal
-
     - name: Pack nuget
       if: ${{ success() }}
       run: |
         $NugetVersion = git describe --tags --abbrev=1 | sed 's/-/./'
         dotnet pack -c Release --no-build -v minimal -o ${{ env.NuGetDirectory }} -p:PackageVersion=$NugetVersion
-    - name: Publish NuGet package
-      if: ${{ success() }}
-      run: dotnet nuget push "${{ env.NuGetDirectory }}\*.nupkg" --api-key "${{ secrets.NUGET_PUSH }}" --source https://api.nuget.org/v3/index.json
     - name: Upload files to a GitHub release
       if: ${{ success() && github.ref_type == 'tag' }}
       uses: svenstaro/upload-release-action@2.7.0
       with:
         file: ${{ env.NuGetDirectory }}\*.nupkg
         file_glob: true
+    - name: Upload nuget as artifact
+      uses: actions/upload-artifact@v3
+      if: ${{ success() }}
+      with:
+        name: nuget-artifact
+        path: ${{ env.NuGetDirectory }}
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish nuget
+
+on:
+  workflow_run:
+    workflows: ["Build, Test & Pack nuget"]
+    types:
+      - completed
+
+jobs:
+  download_and_publish_nuget:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+    - name: 'Download zipped nuget artifact'
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+          });
+          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "nuget-artifact"
+          })[0];
+          var download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+          });
+          var fs = require('fs');
+          fs.writeFileSync('${{ github.workspace }}/nuget.zip', Buffer.from(download.data));
+    - run: unzip nuget.zip
+    - name: Publish NuGet package
+      if: ${{ success() }}
+      run: dotnet nuget push "${{ github.workspace }}/*.nupkg" --api-key "${{ secrets.NUGET_PUSH }}" --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Workflow was splitted into two workflows: ci.yml and publish.yml. ci.yml is building, testing and packing nuget, NOT publishing. Publishing to nuget.org was moved from ci.yml to publish.yml. 

Motivation: publishing to nuget.org demands an access to repo's secrets (NUGET_PUSH secret) from workflow runner, but workflows based on PR's from forked repos doesn't have it (more info https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflows-in-forked-repositories and https://securitylab.github.com/research/github-actions-preventing-pwn-requests/). Suggested approach allows us to publish nuget in separate workflow, triggered after successful build of ci.yml.

Example of failed pipeline because of that nuance with PR from forked repo: https://github.com/progaudi/MsgPack.Light/actions/runs/6588328945/job/17900338440?pr=89

Examples of new successful pipelines:
ci.yml: https://github.com/pavlua/MsgPack.Light/actions/runs/6616128744
publish.yml: https://github.com/pavlua/MsgPack.Light/actions/runs/6616181104